### PR TITLE
Fix warnings which come up when compiling with g++ 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 2.6)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(USE_OPENMP "Enable multi-threading" OFF)
 
@@ -33,8 +35,6 @@ include_directories(${PROJECT_SOURCE_DIR}/include/algorithms/cw-bwt)
 include_directories(${INSTALL_DIR}/src/hopscotch_map/include)
 
 message("Building in ${CMAKE_BUILD_TYPE} mode")
-
-set(CMAKE_CXX_FLAGS "--std=c++11")
 
 if(XXSDS_DYN_MULTI_THREADED)
   find_package(OpenMP REQUIRED)

--- a/include/internal/spsi.hpp
+++ b/include/internal/spsi.hpp
@@ -1102,8 +1102,8 @@ class spsi<leaf_type, B_LEAF, B>::node {
     // size stored in previous counter
     uint64_t previous_size = (j == 0 ? 0 : subtree_sizes[j - 1]);
 
+    assert(i >= previous_size);
     i = i - previous_size;
-    assert(i >= 0);
     if (this->has_leaves()) {
       assert(this->leaves.size() == nr_children);
       assert(this->can_lose());
@@ -1186,6 +1186,7 @@ class spsi<leaf_type, B_LEAF, B>::node {
 
             assert(x->size() == 2 * B_LEAF);
 
+            assert(j > 0);
             --j;  // update the location of x in this's list of children
             // update removal position to be wrt yx (if y is prev)
             i = i + y->size();
@@ -1203,11 +1204,9 @@ class spsi<leaf_type, B_LEAF, B>::node {
           }
 
           if (y_is_prev) {
-            assert(0 <= j);
             assert(j < this->leaves.size());
             this->leaves.erase(this->leaves.begin() + j);
           } else {
-            assert(0 <= j + 1);
             assert(j + 1 < this->leaves.size());
             this->leaves.erase(this->leaves.begin() + j + 1);
           }


### PR DESCRIPTION
1) Removes some trivial assertions (checking if an unsigned integer is >= 0)
2) Sets the required CXX standard in CMakeFiles.txt